### PR TITLE
Add tests and eslint

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["babel-preset-react-native"]
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,7 @@
+---
+"extends":
+  - "eslint-config-defaults/configurations/walmart/es6-react"
+
+"rules":
+  "react/jsx-pascal-case": 0
+  "no-arrow-condition": 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: node_js
+
+node_js:
+  - "4"
+  - "6"
+
+sudo: false
+
+branches:
+  only:
+    - master
+
+before_install:
+  - 'npm install -g npm@3'
+
+script:
+  - 'npm run lint'
+  - 'npm run test'

--- a/lib/components/victory-label.js
+++ b/lib/components/victory-label.js
@@ -15,7 +15,7 @@ export default class extends VictoryLabel {
     const transform = NativeHelpers.getTransform(props);
     const style = NativeHelpers.getStyle(props.style);
     const baseProps = omit(props, ["style", "transform", "events", "scale"]);
-    const dy = props.dy - style.fontSize
+    const dy = props.dy - style.fontSize;
     return (
       <Text {...baseProps} {...style} {...transform} {...props.events} dy={dy}>
         {content}

--- a/lib/native-helpers.js
+++ b/lib/native-helpers.js
@@ -3,6 +3,7 @@ import { omit } from "lodash";
 export default {
 
   getStyle(style) {
+    if (!style) { return undefined; }
     // TODO: more style fixes for Native?
     const strokeProperties = [
       "stroke", "strokeWidth", "strokeOpacity", "strokeDasharray",

--- a/package.json
+++ b/package.json
@@ -18,15 +18,32 @@
   },
   "homepage": "https://github.com/FormidableLabs/victory-core-native#readme",
   "scripts": {
-    "start": "./node_modules/react-native/packager/packager.sh start --reset-cache --projectRoots `pwd`,`pwd`/demo"
+    "start": "./node_modules/react-native/packager/packager.sh start --reset-cache --projectRoots `pwd`,`pwd`/demo",
+    "lint": "eslint test/spec/**/*.js lib/**/*.js",
+    "test": "mocha --compilers test/compiler.js --recursive test/spec/*.js"
+  },
+  "devDependencies": {
+    "babel-core": "^6.13.2",
+    "babel-eslint": "^6.1.2",
+    "babel-preset-react-native": "^1.9.0",
+    "babel-register": "^6.11.6",
+    "chai": "^3.5.0",
+    "enzyme": "^2.4.1",
+    "eslint": "^2.0.0",
+    "eslint-config-defaults": "^10.0.0-1",
+    "eslint-plugin-filenames": "^0.2.0",
+    "eslint-plugin-react": "^3.12.0",
+    "mocha": "^3.0.1",
+    "react-addons-test-utils": "^15.3.0",
+    "react-dom": "^15.3.0",
+    "react-native": ">=0.29.0",
+    "react-native-mock": "^0.2.5",
+    "react-native-svg-mock": "^1.0.2"
   },
   "dependencies": {
     "lodash": "^4.12.0",
-    "react": "^15.1.0",
+    "react": "^15.3.0",
     "react-native-svg": "^3.1.1",
     "victory-core": "^4.5.0"
-  },
-  "devDependencies": {
-    "react-native": ">=0.29.0"
   }
 }

--- a/test/compiler.js
+++ b/test/compiler.js
@@ -1,0 +1,36 @@
+var fs = require("fs");
+var babel = require("babel-core");
+var origJs = require.extensions[".js"];
+
+// Mock react-native and react-native-svg
+require("react-native-mock/mock");
+require("react-native-svg-mock/mock");
+
+// Compile a path with babel
+var compile = function (fileName) {
+  var src = fs.readFileSync(fileName, "utf8");
+  var output = babel.transform(src, {
+    filename: fileName
+  }).code;
+  return output;
+}
+
+// We need to compile a few node_modules
+var shouldCompile = function (fileName) {
+  var should = [
+    "node_modules/victory-chart-native",
+    "node_modules/victory-core",
+    "node_modules/victory-chart"
+  ].some(function (mod) {
+    return fileName.indexOf(mod) >= 0;
+  });
+  return should;
+};
+
+// Babel compile things not in node_modules
+require.extensions[".js"] = function (module, fileName) {
+  if (shouldCompile(fileName) || fileName.indexOf("node_modules/") === -1) {
+    return module._compile(compile(fileName), fileName);
+  }
+  return origJs(module, fileName);
+};

--- a/test/spec/.eslintrc
+++ b/test/spec/.eslintrc
@@ -1,0 +1,7 @@
+---
+"extends":
+  - "eslint-config-defaults/configurations/walmart/es6-react-test"
+
+"rules":
+  "no-arrow-condition": 0
+  "no-magic-numbers": 0

--- a/test/spec/test.js
+++ b/test/spec/test.js
@@ -1,0 +1,20 @@
+import React from "react-native";
+import { render } from "enzyme";
+import { expect } from "chai";
+
+import VictoryContainer from "../../lib/components/victory-container";
+import VictoryLabel from "../../lib/components/victory-label";
+
+const components = [
+  { component: VictoryContainer, name: "VictoryContainer" },
+  { component: VictoryLabel, name: "VictoryLabel" }
+];
+
+describe("Default render", () => {
+  components.forEach((c) => {
+    it(`should work for ${c.name}`, () => {
+      const wrapper = render(React.createElement(c.component));
+      expect(wrapper).to.have.length(1);
+    });
+  });
+});


### PR DESCRIPTION
Also fixed an error in `native-helper` when calling `getStyle` with an undefined style argument, which prevented rendering `<VictoryContainer />` with no `style` prop.

/cc @boygirl 
