### PR TITLE
Update dependencies

### DIFF
--- a/lib/components/victory-clip-container.js
+++ b/lib/components/victory-clip-container.js
@@ -4,7 +4,7 @@ import { NativeHelpers, ClipPath } from "../index";
 import { VictoryClipContainer } from "victory-core";
 
 export default class extends VictoryClipContainer {
-
+  // Overrides method in victory-core
   renderClippedGroup(props, clipId) {
     const { style, events, transform, children, className } = props;
     const nativeStyle = NativeHelpers.getStyle(style);
@@ -19,6 +19,7 @@ export default class extends VictoryClipContainer {
     );
   }
 
+  // Overrides method in victory-core
   renderClipComponent(props, clipId) {
     const { padding, translateX, clipHeight, clipWidth } = props;
     return (
@@ -32,6 +33,7 @@ export default class extends VictoryClipContainer {
     );
   }
 
+  // Overrides method in victory-core
   renderGroup(props) {
     const { style, events, children, transform, className } = props;
     const nativeStyle = NativeHelpers.getStyle(style);

--- a/lib/components/victory-clip-container.js
+++ b/lib/components/victory-clip-container.js
@@ -6,11 +6,11 @@ import { VictoryClipContainer } from "victory-core";
 export default class extends VictoryClipContainer {
 
   renderClippedGroup(props, clipId) {
-    const { style, events, transform, children } = props;
+    const { style, events, transform, children, className } = props;
     const nativeStyle = NativeHelpers.getStyle(style);
     const clipComponent = this.renderClipComponent(props, clipId);
     return (
-      <G {...nativeStyle} {...events} transform={transform}>
+      <G {...nativeStyle} {...events} transform={transform} className={className}>
         {clipComponent}
         <G clipPath={`url(#${clipId})`}>
           {children}
@@ -33,10 +33,10 @@ export default class extends VictoryClipContainer {
   }
 
   renderGroup(props) {
-    const { style, events, children, transform } = props;
+    const { style, events, children, transform, className } = props;
     const nativeStyle = NativeHelpers.getStyle(style);
     return (
-      <G {...nativeStyle} {...events} transform={transform}>
+      <G {...nativeStyle} {...events} transform={transform} className={className}>
         {children}
       </G>
     );

--- a/lib/components/victory-container.js
+++ b/lib/components/victory-container.js
@@ -7,10 +7,10 @@ import { Portal } from "../index";
 export default class extends VictoryContainer {
 
   renderContainer(props, svgProps, style) {
-    const { children } = props;
+    const { children, className } = props;
     const nativeStyle = NativeHelpers.getStyle(style);
     return (
-      <Svg {...nativeStyle} {...svgProps}>
+      <Svg {...nativeStyle} {...svgProps} className={className}>
         {children}
         <Portal ref={this.savePortalRef}/>
       </Svg>

--- a/lib/components/victory-container.js
+++ b/lib/components/victory-container.js
@@ -5,7 +5,7 @@ import { NativeHelpers } from "../index";
 import { Portal } from "../index";
 
 export default class extends VictoryContainer {
-
+  // Overrides method in victory-core
   renderContainer(props, svgProps, style) {
     const { children, className } = props;
     const nativeStyle = NativeHelpers.getStyle(style);

--- a/lib/components/victory-label.js
+++ b/lib/components/victory-label.js
@@ -11,6 +11,7 @@ export default class extends VictoryLabel {
     lineHeight: 1
   };
 
+  // Overrides method in victory-core
   renderElements(props, content) {
     const transform = NativeHelpers.getTransform(props);
     const style = NativeHelpers.getStyle(props.style);

--- a/lib/components/victory-label.js
+++ b/lib/components/victory-label.js
@@ -15,7 +15,7 @@ export default class extends VictoryLabel {
     const transform = NativeHelpers.getTransform(props);
     const style = NativeHelpers.getStyle(props.style);
     const baseProps = omit(props, [
-      "style", "transform", "events", "scale", "lineHeight", "datum"
+      "style", "transform", "events", "scale", "lineHeight", "datum", "className"
     ]);
     const dy = props.dy - this.getFontSize(style);
     return (

--- a/lib/components/victory-primitives/area.js
+++ b/lib/components/victory-primitives/area.js
@@ -5,21 +5,43 @@ import { Area } from "victory-core";
 
 export default class extends Area {
 
+  // Overrides method in victory-core
   renderArea(path, style, events) {
     const areaStroke = style.stroke ? "none" : style.fill;
     const areaStyle = Object.assign({}, style, {stroke: areaStroke});
     const nativeStyle = NativeHelpers.getStyle(areaStyle);
-    return <Path key="area" {...nativeStyle} d={path} {...events}/>;
+    const { role, shapeRendering, className } = this.props;
+    return (
+      <Path
+        key="area"
+        shapeRendering={shapeRendering || "auto"}
+        role={role || "presentation"}
+        className={className}
+        d={path}
+        {...nativeStyle}
+        {...events}
+      />
+    );
   }
 
+  // Overrides method in victory-core
   renderLine(path, style, events) {
     if (!style.stroke || style.stroke === "none" || style.stroke === "transparent") {
       return undefined;
     }
+    const { role, shapeRendering, className } = this.props;
     const lineStyle = Object.assign({}, style, {fill: "none"});
     const nativeStyle = NativeHelpers.getStyle(lineStyle);
     return (
-      <Path key="area-stroke" {...nativeStyle} d={path} {...events}/>
+      <Path
+        key="area-stroke"
+        shapeRendering={shapeRendering || "auto"}
+        role={role || "presentation"}
+        className={className}
+        d={path}
+        {...nativeStyle}
+        {...events}
+      />
     );
   }
 }

--- a/lib/components/victory-primitives/bar.js
+++ b/lib/components/victory-primitives/bar.js
@@ -4,7 +4,7 @@ import { NativeHelpers } from "../../index";
 import { Bar } from "victory-core";
 
 export default class extends Bar {
-   // Overrides method in vicory-core
+   // Overrides method in victory-core
   renderBar(path, style, events) {
     const nativeStyle = NativeHelpers.getStyle(style);
     const { role, shapeRendering, className } = this.props;

--- a/lib/components/victory-primitives/bar.js
+++ b/lib/components/victory-primitives/bar.js
@@ -4,8 +4,19 @@ import { NativeHelpers } from "../../index";
 import { Bar } from "victory-core";
 
 export default class extends Bar {
+   // Overrides method in vicory-core
   renderBar(path, style, events) {
     const nativeStyle = NativeHelpers.getStyle(style);
-    return <Path d={path} {...nativeStyle} {...events}/>;
+    const { role, shapeRendering, className } = this.props;
+    return (
+      <Path
+        className={className}
+        role={role || "presentation"}
+        shapeRendering={shapeRendering || "auto"}
+        d={path}
+        {...nativeStyle}
+        {...events}
+      />
+    );
   }
 }

--- a/lib/components/victory-primitives/candle.js
+++ b/lib/components/victory-primitives/candle.js
@@ -4,11 +4,13 @@ import { NativeHelpers } from "../../index";
 import { Candle } from "victory-core";
 
 export default class extends Candle {
+   // Overrides method in victory-core
   renderWick(props) {
     const nativeStyle = NativeHelpers.getStyle(props.style);
     return <Line {...props} {...nativeStyle}/>;
   }
 
+  // Overrides method in victory-core
   renderCandle(props) {
     const nativeStyle = NativeHelpers.getStyle(props.style);
     return <Rect {...props} {...nativeStyle}/>;

--- a/lib/components/victory-primitives/clip-path.js
+++ b/lib/components/victory-primitives/clip-path.js
@@ -3,6 +3,7 @@ import { ClipPath as Clip, Rect, Defs } from "react-native-svg";
 import { ClipPath } from "victory-core";
 
 export default class extends ClipPath {
+  // Overrides method in vicory-core
   renderClipPath(props, id) {
     return (
       <Defs>

--- a/lib/components/victory-primitives/clip-path.js
+++ b/lib/components/victory-primitives/clip-path.js
@@ -3,7 +3,7 @@ import { ClipPath as Clip, Rect, Defs } from "react-native-svg";
 import { ClipPath } from "victory-core";
 
 export default class extends ClipPath {
-  // Overrides method in vicory-core
+  // Overrides method in victory-core
   renderClipPath(props, id) {
     return (
       <Defs>

--- a/lib/components/victory-primitives/curve.js
+++ b/lib/components/victory-primitives/curve.js
@@ -4,8 +4,20 @@ import { NativeHelpers } from "../../index";
 import { Curve } from "victory-core";
 
 export default class extends Curve {
+  // Overrides method in vicory-core
   renderLine(path, style, events) {
     const nativeStyle = NativeHelpers.getStyle(style);
-    return <Path d={path} {...nativeStyle} {...events}/>;
+    const { role, shapeRendering, className } = this.props;
+    return (
+      <Path
+        className={className}
+        shapeRendering={shapeRendering || "auto"}
+        role={role || "presentation"}
+        vectorEffect="non-scaling-stroke"
+        d={path}
+        {...nativeStyle}
+        {...events}
+      />
+    );
   }
 }

--- a/lib/components/victory-primitives/curve.js
+++ b/lib/components/victory-primitives/curve.js
@@ -4,7 +4,7 @@ import { NativeHelpers } from "../../index";
 import { Curve } from "victory-core";
 
 export default class extends Curve {
-  // Overrides method in vicory-core
+  // Overrides method in victory-core
   renderLine(path, style, events) {
     const nativeStyle = NativeHelpers.getStyle(style);
     const { role, shapeRendering, className } = this.props;

--- a/lib/components/victory-primitives/error-bar.js
+++ b/lib/components/victory-primitives/error-bar.js
@@ -4,7 +4,7 @@ import { NativeHelpers } from "../../index";
 import { ErrorBar } from "victory-core";
 
 export default class extends ErrorBar {
-
+  // Overrides method in vicory-core
   renderLine(props, style, events) {
     const nativeStyle = NativeHelpers.getStyle(style);
     return <Line {...props} {...nativeStyle} {...events}/>;

--- a/lib/components/victory-primitives/error-bar.js
+++ b/lib/components/victory-primitives/error-bar.js
@@ -4,7 +4,7 @@ import { NativeHelpers } from "../../index";
 import { ErrorBar } from "victory-core";
 
 export default class extends ErrorBar {
-  // Overrides method in vicory-core
+  // Overrides method in victory-core
   renderLine(props, style, events) {
     const nativeStyle = NativeHelpers.getStyle(style);
     return <Line {...props} {...nativeStyle} {...events}/>;

--- a/lib/components/victory-primitives/flyout.js
+++ b/lib/components/victory-primitives/flyout.js
@@ -4,7 +4,7 @@ import { Flyout } from "victory-core";
 import { NativeHelpers } from "../../index";
 
 export default class extends Flyout {
-  // Overrides method in vicory-core
+  // Overrides method in victory-core
   renderFlyout(path, style, events) {
     const nativeStyle = NativeHelpers.getStyle(style);
     const { role, shapeRendering, className } = this.props;

--- a/lib/components/victory-primitives/flyout.js
+++ b/lib/components/victory-primitives/flyout.js
@@ -4,10 +4,19 @@ import { Flyout } from "victory-core";
 import { NativeHelpers } from "../../index";
 
 export default class extends Flyout {
+  // Overrides method in vicory-core
   renderFlyout(path, style, events) {
-    const nativeStyle = NativeHelpers.getStyle(style)
+    const nativeStyle = NativeHelpers.getStyle(style);
+    const { role, shapeRendering, className } = this.props;
     return (
-      <Path d={path} {...nativeStyle} {...events}/>
+      <Path
+        className={className}
+        shapeRendering={shapeRendering || "auto"}
+        role={role || "presentation"}
+        d={path}
+        {...nativeStyle}
+        {...events}
+      />
     );
   }
 }

--- a/lib/components/victory-primitives/line.js
+++ b/lib/components/victory-primitives/line.js
@@ -4,7 +4,7 @@ import { NativeHelpers } from "../../index";
 import { Line as VLine } from "victory-core";
 
 export default class extends VLine {
-  // Overrides method in vicory-core
+  // Overrides method in victory-core
   renderAxisLine(props, style, events) {
     const nativeStyle = NativeHelpers.getStyle(style);
     const { role, shapeRendering, className } = this.props;

--- a/lib/components/victory-primitives/line.js
+++ b/lib/components/victory-primitives/line.js
@@ -4,8 +4,20 @@ import { NativeHelpers } from "../../index";
 import { Line as VLine } from "victory-core";
 
 export default class extends VLine {
+  // Overrides method in vicory-core
   renderAxisLine(props, style, events) {
     const nativeStyle = NativeHelpers.getStyle(style);
-    return <Line {...props} {...nativeStyle} {...events} vectorEffect="non-scaling-stroke"/>;
+    const { role, shapeRendering, className } = this.props;
+    return (
+      <Line
+        className={className}
+        role={role || "presentation"}
+        shapeRendering={shapeRendering || "auto"}
+        vectorEffect="non-scaling-stroke"
+        {...props}
+        {...nativeStyle}
+        {...events}
+      />
+    );
   }
 }

--- a/lib/components/victory-primitives/point.js
+++ b/lib/components/victory-primitives/point.js
@@ -4,7 +4,7 @@ import { NativeHelpers } from "../../index";
 import { Point } from "victory-core";
 
 export default class extends Point {
-  // Overrides method in vicory-core
+  // Overrides method in victory-core
   renderPoint(path, style, events) {
     const nativeStyle = NativeHelpers.getStyle(style);
     const { role, shapeRendering, className } = this.props;

--- a/lib/components/victory-primitives/point.js
+++ b/lib/components/victory-primitives/point.js
@@ -4,8 +4,19 @@ import { NativeHelpers } from "../../index";
 import { Point } from "victory-core";
 
 export default class extends Point {
+  // Overrides method in vicory-core
   renderPoint(path, style, events) {
     const nativeStyle = NativeHelpers.getStyle(style);
-    return <Path d={path} {...nativeStyle} {...events}/>;
+    const { role, shapeRendering, className } = this.props;
+    return (
+      <Path
+        className={className}
+        role={role || "presentation"}
+        shapeRendering={shapeRendering || "auto"}
+        d={path}
+        {...nativeStyle}
+        {...events}
+      />
+    );
   }
 }

--- a/lib/components/victory-primitives/slice.js
+++ b/lib/components/victory-primitives/slice.js
@@ -4,7 +4,7 @@ import { Slice } from "victory-core";
 import { NativeHelpers } from "../../index";
 
 export default class extends Slice {
-
+  // Overrides method in victory-core
   renderSlice(path, style, events) {
     const { role, shapeRendering, className } = this.props;
     const nativeStyle = NativeHelpers.getStyle(style);

--- a/lib/components/victory-primitives/slice.js
+++ b/lib/components/victory-primitives/slice.js
@@ -6,13 +6,14 @@ import { NativeHelpers } from "../../index";
 export default class extends Slice {
 
   renderSlice(path, style, events) {
-    const { role, shapeRendering } = this.props;
+    const { role, shapeRendering, className } = this.props;
     const nativeStyle = NativeHelpers.getStyle(style);
     return (
       <Path
-        d={path}
+        className={className}
         role={role || "presentation"}
         shapeRendering={shapeRendering || "auto"}
+        d={path}
         {...nativeStyle}
         {...events}
       />

--- a/lib/components/victory-primitives/voronoi.js
+++ b/lib/components/victory-primitives/voronoi.js
@@ -7,6 +7,7 @@ export default class extends Voronoi {
   renderPoint(paths, style, events) {
     const clipId = `clipPath-${Math.random()}`;
     const nativeStyle = NativeHelpers.getStyle(style);
+    const { className, role, shapeRendering } = this.props;
     return paths.circle ?
       (
         <G>
@@ -17,12 +18,23 @@ export default class extends Voronoi {
           </Defs>
           <Path
             d={paths.circle}
+            className={className}
+            role={role || "presentation"}
+            shapeRendering={shapeRendering || "auto"}
             clipPath={`url(#${clipId})`}
             {...nativeStyle}
             {...events}
           />
         </G>
-      ) :
-      <Path d={paths.voronoi} {...nativeStyle} {...events}/>;
+      ) : (
+      <Path
+        className={className}
+        role={role || "presentation"}
+        shapeRendering={shapeRendering || "auto"}
+        d={paths.voronoi}
+        {...nativeStyle}
+        {...events}
+      />
+    );
   }
 }

--- a/lib/components/victory-primitives/voronoi.js
+++ b/lib/components/victory-primitives/voronoi.js
@@ -4,6 +4,7 @@ import { Voronoi } from "victory-core";
 import { NativeHelpers } from "../../index";
 
 export default class extends Voronoi {
+  // Overrides method in victory-core
   renderPoint(paths, style, events) {
     const clipId = `clipPath-${Math.random()}`;
     const nativeStyle = NativeHelpers.getStyle(style);

--- a/package.json
+++ b/package.json
@@ -34,19 +34,21 @@
     "eslint-plugin-filenames": "^0.2.0",
     "eslint-plugin-react": "^3.12.0",
     "mocha": "^3.0.1",
+    "react": "^15.3.0",
     "react-addons-test-utils": "^15.3.0",
     "react-dom": "^15.3.0",
-    "react-native": "~0.35.0",
+    "react-native": "~0.38.0",
     "react-native-mock": "^0.2.5",
     "react-native-svg": "^4.1.0",
     "react-native-svg-mock": "^1.0.2"
   },
   "peerDependencies": {
+    "react": "^15.3.0",
+    "react-native": "~0.38.0",
     "react-native-svg": "^4.1.0"
   },
   "dependencies": {
     "lodash.omit": "^4.5.0",
-    "react": "^15.3.0",
-    "victory-core": "^9.0.2"
+    "victory-core": "^10.0.2"
   }
 }


### PR DESCRIPTION
This PR:

Updates the victory-core dependency
supports `className` in primitive components
moves react and react-native to peer dependencies